### PR TITLE
fix(config): Bind services to localhost and update cosmos indexer end…

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,13 +15,13 @@ services:
       - ./tmp:/tmp
       - ./sekai:/sekai
     ports:
-      - "26658:26658"           # ABCI
-      - "26657:26657"           # RPC
-      - "26656:26656"           # P2P (gRPC)
-      - "26660:26660"           # Prometheus
-      - "127.0.0.1:8181:8080"   # RPC sCaller
-      - "1317:1317"             # REST API
-      - "9090:9090"             # gRPC
+      - "127.0.0.1:26658:26658"           # ABCI
+      - "127.0.0.1:26657:26657"           # RPC
+      - "26656:26656"                     # P2P (gRPC)
+      - "127.0.0.1:26660:26660"           # Prometheus
+      - "127.0.0.1:8181:8080"             # RPC sCaller
+      - "127.0.0.1:1317:1317"             # REST API
+      - "127.0.0.1:9090:9090"             # gRPC
 
 
     networks:
@@ -42,8 +42,8 @@ services:
         syslog-facility: local0
         tag: "manager"
     ports:
-      - "8080:8080"             # HTTP server
-      - "9000:9000/udp"         # P2P UDP
+      - "127.0.0.1:8080:8080"             # HTTP server
+      - "127.0.0.1:9000:9000/udp"         # P2P UDP
     networks:
       kiranet:
         ipv4_address: 10.1.0.4
@@ -65,7 +65,7 @@ services:
         syslog-facility: local0
         tag: "proxy"
     ports:
-      - "80:8080"               # HTTP proxy
+      - "11000:8080"               # HTTP proxy
     networks:
       kiranet:
         ipv4_address: 10.1.0.10

--- a/worker/cosmos/sai-cosmos-indexer/config.yml
+++ b/worker/cosmos/sai-cosmos-indexer/config.yml
@@ -17,7 +17,7 @@ notifier:
   url: "http://localhost:8885"
   sender_id: "Cosmos"
 
-node_address: "http://localhost:1317"
+node_address: "http://sekai.local:26657"
 start_block: 857
 tx_type: "/kira.bridge.MsgChangeCosmosEthereum"
 sleep_duration: 2


### PR DESCRIPTION
Security and configuration improvements:
- Bind sekai service ports to 127.0.0.1 (ABCI, RPC, Prometheus, REST API, gRPC)
- Bind manager service ports to 127.0.0.1 (HTTP server, P2P UDP)
- Change proxy port mapping from 80:8080 to 11000:8080
- Update cosmos indexer to use sekai.local:26657 instead of localhost:1317
- Keep P2P port 26656 exposed for inter-node communication